### PR TITLE
Load helm for using its function

### DIFF
--- a/math-symbols.el
+++ b/math-symbols.el
@@ -82,6 +82,7 @@
 
 (eval-when-compile (require 'cl))
 (require 'robin)
+(require 'helm)
 
 ;;;; TeX Data
 ;; generate table from from `unimathsymbols.txt'


### PR DESCRIPTION
There are some byte-compile warnings by not loading helm.

```
In math-symbols-helm:
math-symbols.el:778:17:Warning: reference to free variable `helm-map'

In end of data:
math-symbols.el:790:1:Warning: the following functions are not known to be defined:
    helm-candidate-buffer, with-helm-current-buffer, helm
```
